### PR TITLE
Add QuickCheck and test binary conversion identity

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,8 @@
     "purescript-foldable-traversable": "~0.4.2"
   },
   "devDependencies": {
-    "purescript-test-unit": "~4.1.0"
+    "purescript-test-unit": "~4.1.0",
+    "purescript-quickcheck": "^0.12.2"
   },
   "repository": {
     "type": "git",

--- a/src/Data/IntMap/Internal.js
+++ b/src/Data/IntMap/Internal.js
@@ -8,7 +8,7 @@ exports.dec2bin = function dec2bin(dec) {
 }
 
 exports.bin2dec = function bin2dec(bin) {
-  return parseInt(bin, 2);
+  return parseInt(bin, 2) >> 0;
 }
 
 exports.pow = Math.pow;

--- a/test/Data/IntMap.purs
+++ b/test/Data/IntMap.purs
@@ -26,7 +26,6 @@ ex2 = empty
      >| insert 30 30
      >| insert 0  1234
 
-tests :: Test ()
 tests = do
   test "Data.IntMap" do 
     test "lookup in empty map" $ Assert.equal Nothing (lookup 0 ex0)
@@ -49,4 +48,4 @@ tests = do
       Assert.equal empty (filter (const false) ex2)
     test "filter by key" $
       Assert.equal (delete 20 ex2) (filterWithKey (\i _ -> i /= 20) ex2)
-    Internal.tests
+    Internal.testAll

--- a/test/Data/IntMap/Internal.purs
+++ b/test/Data/IntMap/Internal.purs
@@ -20,9 +20,12 @@ props = do
 
 tests = do
     test "binary conversions" do
-      Assert.equal "0" (dec2bin 0)
-      Assert.equal (dec2bin $ runFn2 pow 2 32 - 1) (dec2bin (complement 0)) 
-      Assert.equal "11111111111111111111111111111111" (dec2bin $ runFn2 pow 2 32 - 1) 
+      let minInt = (-2147483648)
+          maxInt =   2147483647
+      Assert.equal                                "0" (dec2bin 0)
+      Assert.equal "11111111111111111111111111111111" (dec2bin (-1))
+      Assert.equal "10000000000000000000000000000000" (dec2bin minInt)
+      Assert.equal  "1111111111111111111111111111111" (dec2bin maxInt)
       Assert.equal 0 (bin2dec "000000000")
       Assert.equal 5 (bin2dec "101")
       Assert.equal 90 (bin2dec "01011010")

--- a/test/Data/IntMap/Internal.purs
+++ b/test/Data/IntMap/Internal.purs
@@ -7,10 +7,18 @@ import           Data.IntMap.Internal
 import           Prelude
 import           Test.Unit            (Test (), test)
 import           Test.Unit.Assert     as Assert
+import           Test.Unit.QuickCheck (quickCheck)
+import           Test.QuickCheck      (Result (), (===))
 
-tests :: Test ()
+testAll = test "Internal" do
+  test "QuickCheck" props
+  test "Unit Tests" tests
+
+props = do
+  test "binary conversion identity" do
+    quickCheck propBinConvIdentity
+
 tests = do
-  test "Internal" do
     test "binary conversions" do
       Assert.equal "0" (dec2bin 0)
       Assert.equal (dec2bin $ runFn2 pow 2 32 - 1) (dec2bin (complement 0)) 
@@ -27,7 +35,6 @@ tests = do
         Assert.equal "10000" (binBranchingBit "01010101" "01000001")
       Assert.equal "1000000" (dec2bin $ highestBit (bin2dec "1010101") (bin2dec "00000000001"))
 
-testInversionTrick :: Test ()
 testInversionTrick =
   test "inversion trick" do 
     let x  = bin2dec "10101010101010101"
@@ -41,3 +48,6 @@ binBranchingBit :: String -> String -> String
 binBranchingBit s1 s2 =
   case branchingBit (bin2dec s1) (bin2dec s2) of
     Mask b -> dec2bin b
+
+propBinConvIdentity :: Int -> Result
+propBinConvIdentity int = (bin2dec <<< dec2bin) int === int

--- a/test/Data/IntMap/Internal.purs
+++ b/test/Data/IntMap/Internal.purs
@@ -10,7 +10,7 @@ import           Test.Unit.Assert     as Assert
 import           Test.Unit.QuickCheck (quickCheck)
 import           Test.QuickCheck      (Result (), (===))
 
-testAll = test "Internal" do
+testAll = test "Data.IntMap.Internal" do
   test "QuickCheck" props
   test "Unit Tests" tests
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,11 +3,11 @@ module Test.Main where
 
 import           Control.Monad.Aff.AVar (AVAR ())
 import           Control.Monad.Eff
+import           Control.Monad.Eff.Random (RANDOM ())
 import           Prelude
 import qualified Test.Data.IntMap       as IntMap
 import           Test.Unit              (TIMER (), runTest, test)
 import           Test.Unit.Console      (TESTOUTPUT ())
 
-main :: Eff (testOutput :: TESTOUTPUT, avar :: AVAR, timer :: TIMER) Unit
-main = runTest do
-  test "IntMap" IntMap.tests
+main :: Eff (testOutput :: TESTOUTPUT, avar :: AVAR, timer :: TIMER, random :: RANDOM) Unit
+main = runTest (test "IntMap" IntMap.tests)

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -6,8 +6,11 @@ import           Control.Monad.Eff
 import           Control.Monad.Eff.Random (RANDOM ())
 import           Prelude
 import qualified Test.Data.IntMap       as IntMap
+import           Test.Data.IntMap.Internal as IntMapInternal
 import           Test.Unit              (TIMER (), runTest, test)
 import           Test.Unit.Console      (TESTOUTPUT ())
 
 main :: Eff (testOutput :: TESTOUTPUT, avar :: AVAR, timer :: TIMER, random :: RANDOM) Unit
-main = runTest (test "IntMap" IntMap.tests)
+main = runTest do
+  IntMap.testAll
+  IntMapInternal.testAll


### PR DESCRIPTION
Adding QuickCheck for testing (#13).

I've added the first property I believe should hold (`bin2dec <<< dec2bin` is `id`, right?), but the case is failing...

But this bits stuff is new to me so I may easily be wrong so please correct me and I'll add different property (when I have `instance Arbitrary IntMap`).
